### PR TITLE
更新 C# SDK 的重试机制，支持自定义域名切换和重试配置优化

### DIFF
--- a/QCloudCSharpSDK/COSXML/COSXML-Netcore.csproj
+++ b/QCloudCSharpSDK/COSXML/COSXML-Netcore.csproj
@@ -11,7 +11,7 @@
     <Deterministic>true</Deterministic>
 
     <PackageId>Tencent.QCloud.Cos.Sdk</PackageId>
-    <Version>5.4.46.0</Version>
+    <Version>5.4.47.0</Version>
     <Authors>Tencent</Authors>
     <Company>Tencent</Company>
     <description>Tencent Cloud COS(Cloud Object Service) .Net SDK</description>

--- a/QCloudCSharpSDK/COSXML/Common/CosVersion.cs
+++ b/QCloudCSharpSDK/COSXML/Common/CosVersion.cs
@@ -9,7 +9,7 @@ namespace COSXML.Common
 {
     public sealed class CosVersion
     {
-        private static string SDKVersion = "5.4.46.0";
+        private static string SDKVersion = "5.4.47.0";
         // 主版本号：第一个数字，产品改动较大，可能无法向后兼容（要看具体项目）
         // 子版本号：第二个数字，增加了新功能，向后兼容 
         // 修正版本号：第三个数字，修复BUG 或优化代码，一般没有添加新功能，向后兼容

--- a/QCloudCSharpSDK/COSXML/CosXmlConfig.cs
+++ b/QCloudCSharpSDK/COSXML/CosXmlConfig.cs
@@ -28,6 +28,8 @@ namespace COSXML
         /// </summary>
         /// <value></value>
         public string host { get; private set; }
+        
+        public string retryHost;
 
         private CosXmlConfig(Builder builder)
         {
@@ -38,6 +40,7 @@ namespace COSXML
             this.isDebug = builder.isDebug;
             this.endpointSuffix = builder.endpointSuffix;
             this.host = builder.host;
+            this.retryHost = builder.retryHost;
         }
 
         /// <summary>
@@ -119,6 +122,8 @@ namespace COSXML
 
             internal string host;
 
+            internal string retryHost;
+            
             /// <summary>
             /// 初始化一个构造器
             /// </summary>
@@ -136,6 +141,12 @@ namespace COSXML
             {
                 this.appid = appid;
 
+                return this;
+            }
+            
+            public Builder SetRetryHost(string host)
+            {
+                this.retryHost = host;
                 return this;
             }
 

--- a/QCloudCSharpSDK/COSXML/Model/CosRequest.cs
+++ b/QCloudCSharpSDK/COSXML/Model/CosRequest.cs
@@ -82,6 +82,9 @@ namespace COSXML.Model
             set { isHttps = value; }
         }
 
+        
+        public int MaxRetry = 3;
+        
         /// <summary>
         /// http method
         /// </summary>

--- a/QCloudCSharpSDK/COSXML/Model/Object/ObjectRequest.cs
+++ b/QCloudCSharpSDK/COSXML/Model/Object/ObjectRequest.cs
@@ -94,7 +94,12 @@ namespace COSXML.Model.Object
         public override string GetHost()
         {
             StringBuilder hostBuilder = new StringBuilder();
-
+            if (!String.IsNullOrEmpty(serviceConfig.retryHost) && !RetryKeepDefaultDomain && RetryUseBackupDomain)
+            {
+                hostBuilder.Append(serviceConfig.retryHost);
+                return hostBuilder.ToString();
+            }
+            
             if (!String.IsNullOrEmpty(serviceConfig.host))
             {
                 hostBuilder.Append(serviceConfig.host);
@@ -125,7 +130,7 @@ namespace COSXML.Model.Object
             String hostStr = hostBuilder.ToString();
             
             //用户保持原域名 和 条件判断重试使用备用域名
-            if (RetryKeepDefaultDomain && RetryUseBackupDomain)
+            if (!RetryKeepDefaultDomain && RetryUseBackupDomain)
             {
                 StringBuilder pattern = new StringBuilder();
                 pattern.Append(".cos.").Append(region).Append(".myqcloud.com");

--- a/QCloudCSharpSDK/COSXML/Network/CommandTask.cs
+++ b/QCloudCSharpSDK/COSXML/Network/CommandTask.cs
@@ -138,6 +138,10 @@ namespace COSXML.Network
                 httpWebRequest.ContentLength = request.Body.ContentLength;
                 request.Body.OnWrite(httpWebRequest.GetRequestStream());
             }
+            else
+            {
+                httpWebRequest.ContentLength = 0L;
+            }
             //print request start log
             PrintReqeustInfo(httpWebRequest);
         }

--- a/QCloudCSharpSDK/COSXML/Network/HttpClient.cs
+++ b/QCloudCSharpSDK/COSXML/Network/HttpClient.cs
@@ -34,8 +34,7 @@ namespace COSXML.Network
         private static Object syncInstance = new Object();
 
         private const int MAX_ACTIVIE_TASKS = 5;
-
-        public int MaxRetry { private get; set;} = 3;
+        
 
         private volatile int activieTasks = 0;
 
@@ -146,7 +145,7 @@ namespace COSXML.Network
             catch (CosServerException serverException)
             {
                 // 状态码为301/302/307时，满足域名切换条件（域名匹配myqcloud.com & 响应不含cos requestid & 开启域名切换开关）时，进行3次重试；其余不重试
-                if (retryIndex < MaxRetry && 
+                if (retryIndex < cosRequest.MaxRetry && 
                     (serverException.statusCode == 301 || serverException.statusCode == 302 || serverException.statusCode == 307))
                 {
                     if (request.Host.Contains("myqcloud.com") && serverException.requestId == String.Empty)
@@ -156,9 +155,9 @@ namespace COSXML.Network
                     cosRequest.SetRequestHeader("x-cos-sdk-retry", "true");
                     InternalExcute(cosRequest, cosResult, credentialProvider, retryIndex + 1);
                 }
-                else if (retryIndex < MaxRetry && serverException.statusCode >= 500)
+                else if (retryIndex < cosRequest.MaxRetry && serverException.statusCode >= 500)
                 {
-                    if (retryIndex == MaxRetry - 1)
+                    if (retryIndex == cosRequest.MaxRetry - 1 || !cosRequest.RetryKeepDefaultDomain)//最后一次切换域名
                     {
                         cosRequest.RetryUseBackupDomain = true;
                     }

--- a/QCloudCSharpSDK/COSXMLTests/ObjectTest.cs
+++ b/QCloudCSharpSDK/COSXMLTests/ObjectTest.cs
@@ -1973,6 +1973,7 @@ namespace COSXMLTests
         {
             GetObjectRequest request = new GetObjectRequest(bucket, commonKey, localDir, localFileName);
             request.LimitTraffic(8 * 1024 * 1024);
+            request.MaxRetry = 2;
 
             //执行请求
             COSXMLDownloadTask downloadTask = new COSXMLDownloadTask(request);

--- a/QCloudCSharpSDK/COSXMLTests/Utils/RequestTest.cs
+++ b/QCloudCSharpSDK/COSXMLTests/Utils/RequestTest.cs
@@ -42,9 +42,6 @@ namespace COSXML.Utils.Tests{
             }
 
             req.RequestUrlString = "test-url";
-            HttpClient httpClient = HttpClient.GetInstance();
-            var maxRetry = httpClient.MaxRetry = 5;
-            Assert.AreEqual(5, maxRetry);
             // CosXmlConfig.Builder cosXmlConfig = new CosXmlConfig();
             try
             {


### PR DESCRIPTION
1、控制请求重试次数
2、重试域名切换
3、ContentLength 兜底